### PR TITLE
Remove a rename exception when setting a new doc_id

### DIFF
--- a/src/paperwork/backend/common/doc.py
+++ b/src/paperwork/backend/common/doc.py
@@ -274,11 +274,12 @@ class BasicDoc(object):
             new_docid = new_base_docid + ("_%02d" % idx)
             new_docpath = os.path.join(workdir, new_docid)
 
-        print ("Changing docid: %s -> %s"
-               % (self.path, new_docpath))
-        os.rename(self.path, new_docpath)
         self.__docid = new_docid
-        self.path = new_docpath
+        if self.path != new_docpath:
+            print ("Changing docid: %s -> %s"
+                   % (self.path, new_docpath))
+            os.rename(self.path, new_docpath)
+            self.path = new_docpath
 
     docid = property(__get_docid, __set_docid)
 


### PR DESCRIPTION
Changing docid: /home/user/papers/20130511_2021_43_00 -> /home/user/papers/20130511_2021_43_00
Workers: [Importing file] ended
Worker [Importing file] raised an exception: [Errno 2] Aucun fichier ou dossier de ce type
Traceback (most recent call last):
  File "/home/user/paperwork/src/paperwork/frontend/workers.py", line 47, in run
    worker._wrapper(**kwargs)
  File "/home/user/paperwork/src/paperwork/frontend/workers.py", line 154, in _wrapper
    self.__last_ret_value = BasicWorker._wrapper(self, **kwargs)
  File "/home/user/paperwork/src/paperwork/frontend/workers.py", line 105, in _wrapper
    return self.do(**kwargs)
  File "/home/user/paperwork/src/paperwork/frontend/mainwindow.py", line 689, in do
    self.__main_win.doc)
  File "/home/user/paperwork/src/paperwork/backend/docimport.py", line 126, in import_doc
    doc.docid += ("_%02d" % idx)
  File "/home/user/paperwork/src/paperwork/backend/common/doc.py", line 279, in __set_docid
    os.rename(self.path, new_docpath)
