### PR TITLE
fixing a typo

### DIFF
--- a/src/paperwork/frontend/mainwindow.py
+++ b/src/paperwork/frontend/mainwindow.py
@@ -367,7 +367,7 @@ class JobIndexUpdater(Job):
 
         self.emit('index-update-progression', 0.75,
                   _("Writing index ..."))
-        self.wait()
+        self.__wait()
         self.index_updater.commit()
         self.emit('index-update-progression', 1.0, "")
         self.emit('index-update-end')


### PR DESCRIPTION
Paperwork were raising `ERROR  paperwork.frontend.jobs        ===> Job IndexUpdater:0 raised an exception: <type 'exceptions.AttributeError'>: 'JobIndexUpdater' object has no attribute 'wait'`
