### PR TITLE
Update paperwork.desktop

### DIFF
--- a/data/paperwork.desktop
+++ b/data/paperwork.desktop
@@ -8,4 +8,4 @@ Terminal=false
 Comment=Make dead trees grepable
 Exec=paperwork
 Name=Paperwork
-Icon=paperwork.svg
+Icon=paperwork


### PR DESCRIPTION
value "paperwork.svg" for key "Icon" in group "Desktop Entry" is an icon name with an extension, but there should be no extension as described in the Icon Theme Specification if the value is not an absolute path.
