### PR TITLE
Add configuration for scanner mode

### DIFF
--- a/src/paperwork/frontend/settingswindow/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow/settingswindow.glade
@@ -9,6 +9,14 @@
       <column type="gchararray"/>
     </columns>
   </object>
+  <object class="GtkListStore" id="liststoreMode">
+    <columns>
+      <!-- column-name userName -->
+      <column type="gchararray"/>
+      <!-- column-name value -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkListStore" id="liststoreOcrAngles">
     <columns>
       <!-- column-name userName -->
@@ -157,7 +165,7 @@
                           <object class="GtkTable" id="tableScannerSettings">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="n_rows">3</property>
+                            <property name="n_rows">4</property>
                             <property name="n_columns">2</property>
                             <property name="column_spacing">10</property>
                             <property name="row_spacing">5</property>
@@ -258,6 +266,40 @@
                                 <property name="right_attach">2</property>
                                 <property name="top_attach">2</property>
                                 <property name="bottom_attach">3</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label13">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Mode</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">3</property>
+                                <property name="bottom_attach">4</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="comboboxMode">
+                                <property name="visible">True</property>
+                                <property name="sensitive">False</property>
+                                <property name="can_focus">False</property>
+                                <property name="active">0</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="cellrenderertext6"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">3</property>
+                                <property name="bottom_attach">4</property>
                                 <property name="y_options">GTK_FILL</property>
                               </packing>
                             </child>

--- a/src/paperwork/frontend/util/config.py
+++ b/src/paperwork/frontend/util/config.py
@@ -241,6 +241,10 @@ def load_config():
         'scanner_sources' : PaperworkSetting("Scanner", "Sources",
                                              lambda: _PaperworkCfgStringList(""),
                                              _PaperworkCfgStringList),
+        'scanner_mode' : PaperworkSetting("Scanner", "Mode"),
+        'scanner_modes' : PaperworkSetting("Scanner", "Modes",
+                                           lambda: _PaperworkCfgStringList(""),
+                                           _PaperworkCfgStringList),
         'scan_time' : _ScanTimes(),
         'zoom_level' : PaperworkSetting("GUI", "zoom_level", lambda: 0.0, float),
     }


### PR DESCRIPTION
Scanners may support a variety of imaging modes.  Add a configuration
box that permits the user to select which should be used.

Signed-off-by: Ross Vandegrift ross@kallisti.us
