### PR TITLE
Add configuration for scanner mode

### DIFF
--- a/src/paperwork/backend/config.py
+++ b/src/paperwork/backend/config.py
@@ -272,6 +272,26 @@ class PaperworkConfig(object):
     scanner_resolution = property(__get_scanner_resolution,
                                   __set_scanner_resolution)
 
+    def __get_scanner_mode(self):
+        """
+        This is the mode of the scannner used for normal scans.
+
+        String.
+        """
+        try:
+            return self._configparser.get("Scanner", "Mode")
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            return None
+
+    def __set_scanner_mode(self, mode):
+        """
+        Set the scanner mode used for normal scans.
+        """
+        self._configparser.set("Scanner", "Mode", str(mode))
+
+    scanner_mode = property(__get_scanner_mode,
+                            __set_scanner_mode)
+
     def __get_scanner_calibration(self):
         """
         Scanner calibration
@@ -363,15 +383,7 @@ class PaperworkConfig(object):
         """
         scanner = pyinsane.Scanner(self.scanner_devid)
         scanner.options['resolution'].value = self.scanner_resolution
-        if "Color" in scanner.options['mode'].constraint:
-            scanner.options['mode'].value = "Color"
-            logger.info("Scanner mode set to 'Color'")
-        elif "Gray" in scanner.options['mode'].constraint:
-            scanner.options['mode'].value = "Gray"
-            logger.info("Scanner mode set to 'Gray'")
-        else:
-            logger.warn("WARNING: "
-                    "Unable to set scanner mode ! May be 'Lineart'")
+        scanner.options['mode'].value = self.scanner_mode
         return scanner
 
     def __get_toolbar_visible(self):

--- a/src/paperwork/frontend/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow.glade
@@ -16,9 +16,17 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes" context="Scanner device detection &amp; Available resolution detection">Loading ...</col>
+        <col id="0" translatable="yes" context="Scanner device detection &amp; Available resolution detection &amp; Available mode detection">Loading ...</col>
       </row>
     </data>
+  </object>
+  <object class="GtkListStore" id="liststoreMode">
+    <columns>
+      <!-- column-name userName -->
+      <column type="gchararray"/>
+      <!-- column-name value -->
+      <column type="gchararray"/>
+    </columns>
   </object>
   <object class="GtkListStore" id="liststoreOcrLang">
     <columns>
@@ -138,7 +146,7 @@
                           <object class="GtkTable" id="tableScannerSettings">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="n_rows">2</property>
+                            <property name="n_rows">3</property>
                             <property name="n_columns">2</property>
                             <property name="column_spacing">10</property>
                             <property name="row_spacing">5</property>
@@ -211,6 +219,42 @@
                                 <property name="right_attach">2</property>
                                 <property name="top_attach">1</property>
                                 <property name="bottom_attach">2</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="comboboxMode">
+                                <property name="visible">True</property>
+                                <property name="sensitive">False</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">liststoreLoading</property>
+                                <property name="active">0</property>
+                                <property name="id_column">0</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="cellrenderertext4"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Mode</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
+                                <property name="x_options">GTK_FILL</property>
                                 <property name="y_options">GTK_FILL</property>
                               </packing>
                             </child>

--- a/src/paperwork/frontend/settingswindow.py
+++ b/src/paperwork/frontend/settingswindow.py
@@ -216,6 +216,75 @@ class JobFactoryResolutionFinder(JobFactory):
         return job
 
 
+class JobModeFinder(Job):
+    __gsignals__ = {
+        'mode-finding-start': (GObject.SignalFlags.RUN_LAST,
+                                     None, ()),
+        'mode-found': (GObject.SignalFlags.RUN_LAST, None,
+                             (GObject.TYPE_STRING,  # user name
+                              GObject.TYPE_STRING,  # mode value
+                              GObject.TYPE_BOOLEAN)),  # is the active one
+        'mode-finding-end': (GObject.SignalFlags.RUN_LAST,
+                                   None, ())
+    }
+
+    can_stop = False
+    priority = 490
+
+    def __init__(self, factory, id,
+                 selected_mode,
+                 devid):
+        Job.__init__(self, factory, id)
+        self.__selected_mode = selected_mode
+        self.__devid = devid
+
+    def do(self):
+        self.emit("mode-finding-start")
+        try:
+            logger.info("Looking for mode of device [%s]" % (self.__devid))
+            device = pyinsane.Scanner(name=self.__devid)
+            sys.stdout.flush()
+            modes = device.options['mode'].constraint
+            logger.info("Modes found: %s" % str(modes))
+            sys.stdout.flush()
+
+            for mode in modes:
+                self.emit('mode-found', mode, mode,
+                          (mode == self.__selected_mode))
+        finally:
+            self.emit("mode-finding-end")
+
+
+GObject.type_register(JobModeFinder)
+
+
+class JobFactoryModeFinder(JobFactory):
+    def __init__(self, settings_win, selected_mode):
+        JobFactory.__init__(self, "ModeFinder")
+        self.__settings_win = settings_win
+        self.__selected_mode = selected_mode
+
+    def make(self, devid):
+        job = JobModeFinder(self, next(self.id_generator),
+                                  self.__selected_mode,
+                                  devid)
+        job.connect('mode-finding-start',
+                    lambda job: GObject.idle_add(
+                        self.__settings_win.on_finding_start_cb,
+                        self.__settings_win.device_settings['mode']))
+        job.connect('mode-found',
+                    lambda job, user_name, store_name, active:
+                    GObject.idle_add(
+                        self.__settings_win.on_value_found_cb,
+                        self.__settings_win.device_settings['mode'],
+                        user_name, store_name, active))
+        job.connect('mode-finding-end',
+                    lambda job: GObject.idle_add(
+                        self.__settings_win.on_finding_end_cb,
+                        self.__settings_win.device_settings['mode']))
+        return job
+
+
 class JobCalibrationScan(Job):
     __gsignals__ = {
         'calibration-scan-start': (GObject.SignalFlags.RUN_LAST, None,
@@ -369,6 +438,8 @@ class ActionSelectScanner(SimpleAction):
         # no point in trying to stop the previous jobs, they are unstoppable
         job = self.__settings_win.job_factories['resolution_finder'].make(devid)
         self.__settings_win.schedulers['main'].schedule(job)
+        job = self.__settings_win.job_factories['mode_finder'].make(devid)
+        self.__settings_win.schedulers['main'].schedule(job)
 
 
 class ActionApplySettings(SimpleAction):
@@ -395,6 +466,12 @@ class ActionApplySettings(SimpleAction):
         if idx >= 0:
             resolution = setting['stores']['loaded'][idx][1]
             self.__config.scanner_resolution = resolution
+
+        setting = self.__settings_win.device_settings['mode']
+        idx = setting['gui'].get_active()
+        if idx >= 0:
+            mode = setting['stores']['loaded'][idx][1]
+            self.__config.scanner_mode = mode
 
         setting = self.__settings_win.ocr_settings['lang']
         idx = setting['gui'].get_active()
@@ -508,6 +585,15 @@ class SettingsWindow(GObject.GObject):
                 'nb_elements': 0,
                 'active_idx': -1,
             },
+            "mode": {
+                'gui': widget_tree.get_object("comboboxMode"),
+                'stores': {
+                    'loading': widget_tree.get_object("liststoreLoading"),
+                    'loaded': widget_tree.get_object("liststoreMode"),
+                },
+                'nb_elements': 0,
+                'active_idx': -1,
+            },
         }
 
         self.ocr_settings = {
@@ -539,6 +625,8 @@ class SettingsWindow(GObject.GObject):
             "resolution_finder": JobFactoryResolutionFinder(self,
                 config.scanner_resolution,
                 config.RECOMMENDED_RESOLUTION),
+            "mode_finder": JobFactoryModeFinder(self,
+                config.scanner_mode),
             "scan": JobFactoryCalibrationScan(
                 self,
                 self.calibration['image_viewport'],


### PR DESCRIPTION
Scanners may support a variety of imaging modes.  Add a configuration box
that permits the user to select which should be used.

Signed-off-by: Ross Vandegrift ross@kallisti.us
