### PR TITLE
Remove the shebang line in paperwork.desktop

### DIFF
--- a/data/paperwork.desktop
+++ b/data/paperwork.desktop
@@ -1,5 +1,3 @@
-#!/usr/bin/env xdg-open
-
 [Desktop Entry]
 Version=1.0
 Type=Application


### PR DESCRIPTION
Other applications do not have it. Moreover it makes debian’s lintian
trigger a warning.
