### PR TITLE
Update install.debian.markdown to add pyocr which is neede by paperwork

### DIFF
--- a/doc/install.debian.markdown
+++ b/doc/install.debian.markdown
@@ -36,7 +36,7 @@ For some reason,
 so you will have to install some dependencies yourself with python-pip:
 
     $ sudo apt-get install python-pip
-    $ sudo pip install numpy scikit-learn
+    $ sudo pip install numpy scikit-learn pyocr
 
 Optional:
 Spell checking is used to improve page orientation detection, so:


### PR DESCRIPTION
Try to install today but pyocr was missing to execute pip install paperwork
