### PR TITLE
Add uk translation

### DIFF
--- a/locale/uk.po
+++ b/locale/uk.po
@@ -1,0 +1,841 @@
+# Ukrainian translations for PACKAGE package
+# Переклад українською для пакету PACKAGE.
+# Copyright (C) 2017 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2017.
+# Daniel Korostil <ted.korostiled@gmail.com>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-05-03 00:11+0300\n"
+"PO-Revision-Date: 2017-05-03 16:38+0300\n"
+"Last-Translator: Daniel Korostil <ted.korostiled@gmail.com>\n"
+"Language-Team: linux.org.ua\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Virtaal 0.7.1\n"
+
+#: src/paperwork/frontend/activation/__init__.py:64
+msgid "No activation key provided"
+msgstr "Не надано ключа активування"
+
+#: src/paperwork/frontend/activation/__init__.py:81
+#: src/paperwork/frontend/activation/__init__.py:116
+msgid "Invalid activation key (too short)"
+msgstr "Неправильний ключ активування (закороткий)"
+
+#: src/paperwork/frontend/activation/__init__.py:88
+msgid "Invalid activation key (bad prefix: {})"
+msgstr "Неправильний ключ активування (Помилковий префікс: {})"
+
+#: src/paperwork/frontend/activation/__init__.py:99
+msgid "Email does not match the activation key"
+msgstr "Електронна скринька не збігається з ключем"
+
+#: src/paperwork/frontend/activation/__init__.py:112
+msgid "Activation key is corrupted"
+msgstr "Ключ активування — пошкоджено"
+
+#: src/paperwork/frontend/activation/__init__.py:119
+msgid "Invalid activation key"
+msgstr "Неправильний ключ активування"
+
+#: src/paperwork/frontend/activation/__init__.py:282
+msgid "Activation successful. Please restart Paperwork"
+msgstr "Активування завершено. Перезапустіть програму"
+
+#: src/paperwork/frontend/settingswindow/__init__.py:151
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: src/paperwork/frontend/settingswindow/__init__.py:152
+msgid "Flatbed"
+msgstr "Планшетний"
+
+#: src/paperwork/frontend/settingswindow/__init__.py:153
+msgid "Automatic Feeder"
+msgstr "Автоматична подача"
+
+#: src/paperwork/frontend/settingswindow/__init__.py:247
+msgid " (recommended)"
+msgstr " (бажано)"
+
+#: src/paperwork/frontend/settingswindow/__init__.py:366
+msgid "No paper to scan"
+msgstr "Немає що сканувати"
+
+#: src/paperwork/frontend/settingswindow/__init__.py:371
+#: src/paperwork/frontend/settingswindow/__init__.py:966
+msgid "Error while scanning: {}"
+msgstr "Помилка сканування: {}"
+
+#: src/paperwork/frontend/multiscan/__init__.py:54
+#: src/paperwork/frontend/multiscan/__init__.py:98
+#: src/paperwork/frontend/multiscan/__init__.py:100
+#, python-format
+msgid "Document %d"
+msgstr "Документ %d"
+
+#: src/paperwork/frontend/multiscan/__init__.py:152
+#: src/paperwork/frontend/mainwindow/__init__.py:1374
+msgid "Scan failed: No paper found"
+msgstr "Не вдалося зісканувати: не знайдено що"
+
+#: src/paperwork/frontend/multiscan/__init__.py:154
+#: src/paperwork/frontend/mainwindow/__init__.py:1376
+msgid "Scan failed: {}"
+msgstr "Не вдалося зісканувати: {}"
+
+#: src/paperwork/frontend/multiscan/__init__.py:350
+#, python-format
+msgid "Current document (%s)"
+msgstr "Поточний документ (%s)"
+
+#: src/paperwork/frontend/multiscan/__init__.py:388
+msgid "Scanning"
+msgstr "Сканування"
+
+#: src/paperwork/frontend/multiscan/__init__.py:393
+msgid "Reading"
+msgstr "Читання"
+
+#: src/paperwork/frontend/multiscan/__init__.py:401
+msgid "Done"
+msgstr "Зроблено"
+
+#: src/paperwork/frontend/multiscan/__init__.py:407
+msgid "All the pages have been scanned"
+msgstr "Всі сторінки зіскановано"
+
+#: src/paperwork/frontend/multiscan/__init__.py:427
+#, python-format
+msgid "Less pages than expected have been Img (got %d pages)"
+msgstr "Зіскановано менше сторінок, ніж очікувано (лише %d сторінок)"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:67
+msgid "Keyword(s)"
+msgstr "Ключові слова:"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:115
+#: src/paperwork/frontend/labeleditor/labeleditor.glade.h:2
+msgid "Label"
+msgstr "Мітка"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:127
+msgid "From:"
+msgstr "Від:"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:133
+msgid "to:"
+msgstr "до:"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:239
+msgid "Date"
+msgstr "Дата"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:271
+msgid "and"
+msgstr "і"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:272
+msgid "or"
+msgstr "або"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:289
+msgid "not"
+msgstr "не"
+
+#: src/paperwork/frontend/searchdialog/__init__.py:313
+msgid "Remove"
+msgstr "Вилучити"
+
+#: src/paperwork/frontend/diag/__init__.py:41
+msgid "system's information"
+msgstr "системна інформація"
+
+#: src/paperwork/frontend/diag/__init__.py:42
+msgid "document statistics"
+msgstr "статистика документа"
+
+#: src/paperwork/frontend/diag/__init__.py:43
+msgid "scanner's information"
+msgstr "інформація про сканер"
+
+#: src/paperwork/frontend/diag/__init__.py:297
+msgid "Please wait. It may take a few minutes ..."
+msgstr "Заждіть. Це може протривати кілька хвилин…"
+
+#: src/paperwork/frontend/diag/__init__.py:320
+msgid "Getting {} ({}%)"
+msgstr "Одержання {} ({}%)"
+
+#: src/paperwork/frontend/diag/__init__.py:327
+msgid "Diagnostic information are ready"
+msgstr "Діагностична інформація готова"
+
+#: src/paperwork/frontend/diag/__init__.py:338
+#: src/paperwork/frontend/mainwindow/__init__.py:2163
+msgid "Save as"
+msgstr "Зберегти як"
+
+#: src/paperwork/frontend/util/dialog.py:36
+msgid "Scanner not found (is your scanner turned on ?)"
+msgstr "Не знайдено сканера (сканер увімкнений?)"
+
+#: src/paperwork/frontend/util/dialog.py:39
+msgid "Scanner not found (is your scanner turned on ?) (error was: {})"
+msgstr "Не знайдено сканера (сканер увімкнений?) (помилка: {})"
+
+#: src/paperwork/frontend/util/dialog.py:72
+msgid "Are you sure ?"
+msgstr "Впевнені?"
+
+#: src/paperwork/frontend/util/__init__.py:172
+#, python-format
+msgid "%3.1f bytes"
+msgstr "%3.1f байтів"
+
+#: src/paperwork/frontend/util/__init__.py:173
+#, python-format
+msgid "%3.1f KiB"
+msgstr "%3.1f КіБ"
+
+#: src/paperwork/frontend/util/__init__.py:174
+#, python-format
+msgid "%3.1f MiB"
+msgstr "%3.1f МіБ"
+
+#: src/paperwork/frontend/util/__init__.py:175
+#, python-format
+msgid "%3.1f GiB"
+msgstr "%3.1f ГіБ"
+
+#: src/paperwork/frontend/util/__init__.py:176
+#, python-format
+msgid "%3.1f TiB"
+msgstr "%3.1f ТіБ"
+
+#: src/paperwork/frontend/util/progressivelist.py:193
+#: src/paperwork/frontend/mainwindow/__init__.py:145
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:1
+msgid "Loading ..."
+msgstr "Завантаження…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:256
+msgid "Checking ..."
+msgstr "Перевіряння…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:413
+msgid "Indexing new document ..."
+msgstr "Індексування нового документа…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:415
+msgid "Reindexing modified document ..."
+msgstr "Переіндексування зміненого документа…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:417
+msgid "Removing deleted document from index ..."
+msgstr "Вилучення відкинутих документів з індекса…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:442
+msgid "Writing index ..."
+msgstr "Записування індексу…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1506
+msgid "All supported file formats"
+msgstr "Усі підтримувані формати файлів"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1510
+msgid "Any file"
+msgstr "Будь-який файл"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1553
+#, python-format
+msgid "Don't know how to import '%s'. Sorry."
+msgstr "Невідомо як імпортувати «%s»."
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1567
+msgid "No new document to import found"
+msgstr "Не знайдено жодного нового документа"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1580
+msgid "Import failed: {}"
+msgstr "Не вдалось імпортувати: {}"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1593
+msgid "Imported:\n"
+msgstr "Імпортовано: \n"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1600
+msgid "Import successful"
+msgstr "Успішно імпортовано"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1606
+msgid "Delete imported files"
+msgstr "Вилучити імпортовані файли"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1614
+msgid "Would you like to move the original file(s) to trash?\n"
+msgstr "Бажаєте перенести первинні файли в смітник?"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1630
+msgid "Imported file(s) deleted"
+msgstr "Імпортовані файли вилучено"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1852
+msgid "No simplification"
+msgstr "Без спрощення"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1854
+msgid "Grayscale"
+msgstr "Тони сірого"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1855
+msgid "Soft"
+msgstr "М'який"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1856
+msgid "Grayscale + soft"
+msgstr "Тони сірого + м'який"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1857
+msgid "Black and white"
+msgstr "Чорний і білий"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1858
+msgid "Hard"
+msgstr "Твердий"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:1859
+msgid "Extreme"
+msgstr "Надзвичайний"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:2013
+msgid "Multiple PDF in a folder"
+msgstr "Кілька PDF у теці"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:2028
+msgid "Export page"
+msgstr "Експортувати сторінку"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:2047
+msgid "Export document"
+msgstr "Експортувати документ"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:2052
+msgid "Export documents"
+msgstr "Експортувати документи"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:2173
+msgid "Save in"
+msgstr "Зберегти в"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:2934
+msgid "Paperwork"
+msgstr "Паперова робота"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3046
+msgid "Trial period has expired"
+msgstr "Випробувальний термін вичерпано"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3047
+msgid "Everything will work as usual, except we've"
+msgstr "Все буде працювати як годинник, але не ми"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3048
+msgid "switched all the fonts to {}"
+msgstr "перемкнути всі шрифти на {}"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3050
+msgid "until you get an activation key"
+msgstr "допоки не буде ключа активування"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3052
+msgid "You can go to https://openpaper.work/activation/"
+msgstr "Перейдіть до https://openpaper.work/activation/"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3053
+msgid "to get an activation key"
+msgstr "для одержання ключа"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3058
+msgid "Trial period: {} days remaining"
+msgstr "Випробувальний період: залишилось {} днів"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3062
+msgid "A new version is available:"
+msgstr "Доступна нова версія:"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3063
+msgid "Paperwork {}"
+msgstr "Паперова робота {}"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3156
+msgid "Documentation"
+msgstr "Документація"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3462
+#, python-format
+msgid "/ %d"
+msgstr "/ %d"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3557
+msgid "Computing ..."
+msgstr "Обрахування…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3847
+msgid "Examining imported file(s) ..."
+msgstr "Оцінювання імпортованих файлів…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3887
+#: src/paperwork/frontend/mainwindow/__init__.py:3890
+msgid "Exporting ..."
+msgstr "Експортування…"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3896
+msgid "Export finished"
+msgstr "Екпортування завершено"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3897
+msgid "Export of {} as {} finished"
+msgstr "Експортування {} як {} завершено"
+
+#: src/paperwork/frontend/mainwindow/__init__.py:3907
+msgid "Export failed: {}"
+msgstr "не вдалося експортувати: {}"
+
+#: src/paperwork/frontend/mainwindow/docs.py:1236
+#: src/paperwork/frontend/mainwindow/docs.py:1243
+msgid "Loading thumbnails ..."
+msgstr "Завантаження мініатюр…"
+
+#: src/paperwork/frontend/mainwindow/docs.py:1402
+msgid "Invalid date format: {}"
+msgstr "Неправильний формат дати: {}"
+
+#: src/paperwork/frontend/mainwindow/docs.py:1649
+#, python-format
+msgid "Updating label (%s) ..."
+msgstr "Оновлення мітки (%s)…"
+
+#: src/paperwork/frontend/mainwindow/docs.py:1655
+#, python-format
+msgid "Deleting label (%s) ..."
+msgstr "Вилучення мітки (%s)…"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1220
+msgid "Copy selected text"
+msgstr "Скопіювати вибраний текст"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1232
+msgid "Edit"
+msgstr "Редагувати"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1244
+msgid "Delete page"
+msgstr "Вилучити сторінку"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1260
+#: src/paperwork/frontend/mainwindow/export.glade.h:1
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1267
+msgid "Crop"
+msgstr "Обрізати"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1274
+msgid "Rotate counter-clockwise"
+msgstr "Обернути проти годинникової стрілки"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1281
+msgid "Rotate clockwise"
+msgstr "Обернути за годинниковою стрілкою"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1286
+msgid "Automatic Color Equalization"
+msgstr "Автоматичне вирівнювання кольору"
+
+#: src/paperwork/frontend/mainwindow/pages.py:1293
+msgid "Apply"
+msgstr "Застосувати"
+
+#: ../paperwork-backend/paperwork_backend/common/doc.py:329
+msgid "New document"
+msgstr "Створити документ"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:38
+#: ../paperwork-backend/paperwork_backend/docimport.py:148
+#: ../paperwork-backend/paperwork_backend/docimport.py:244
+msgid "PDF"
+msgstr "PDF"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:39
+#: ../paperwork-backend/paperwork_backend/docimport.py:149
+#: ../paperwork-backend/paperwork_backend/docimport.py:245
+#: ../paperwork-backend/paperwork_backend/docimport.py:319
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:7
+msgid "Document(s)"
+msgstr "Документи"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:40
+#: ../paperwork-backend/paperwork_backend/docimport.py:318
+msgid "Image file(s)"
+msgstr "Зображення"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:41
+#: ../paperwork-backend/paperwork_backend/docimport.py:150
+#: ../paperwork-backend/paperwork_backend/docimport.py:246
+#: ../paperwork-backend/paperwork_backend/docimport.py:320
+msgid "Page(s)"
+msgstr "Сторінки"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:161
+msgid "Import PDF"
+msgstr "Імпортувати PDF"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:253
+msgid "PDF folder"
+msgstr "Теку PDF"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:257
+msgid "Import each PDF in the folder as a new document"
+msgstr "Імпортувати кожен PDF в теку як новий документ"
+
+#: ../paperwork-backend/paperwork_backend/docimport.py:335
+msgid "Append the image to the current document"
+msgstr "Додати зображення до поточного документу"
+
+#: src/paperwork/frontend/activation/activationdialog.glade.h:1
+msgid "Obtain an activation key"
+msgstr "Одержати ключ активування"
+
+#: src/paperwork/frontend/activation/activationdialog.glade.h:2
+msgid "Activation key"
+msgstr "Ключ активування"
+
+#: src/paperwork/frontend/activation/activationdialog.glade.h:3
+msgid "Email"
+msgstr "Пошта"
+
+#: src/paperwork/frontend/activation/activationdialog.glade.h:4
+msgid "Must be the same than the one used to get the activation key"
+msgstr "Повинно збігатись з тим, що використовувалось для одержання ключа"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:2
+msgid "Settings"
+msgstr "параметри"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:3
+msgid "Select a folder"
+msgstr "Вибрати теку"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:4
+msgid "Work directory"
+msgstr "Робоча тека"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:5
+msgid "<b>General</b>"
+msgstr "<b>Загальне</b>"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:6
+msgid "Resolution"
+msgstr "Роздільність"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:7
+msgid "Default source"
+msgstr "Типове джерело"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:8
+msgid "Device"
+msgstr "Пристрій"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:9
+msgid "<b>Scanner</b>"
+msgstr "<b>Сканер</b>"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:10
+msgid "Language"
+msgstr "Мова"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:11
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:12
+msgid "<b>OCR</b>"
+msgstr "<b>Отекстування</b>"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:13
+msgid "Check for updates"
+msgstr "Перевірити на оновлення"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:14
+msgid "Send anonymous usage statistics"
+msgstr "Надсилати анонімну статистику використання"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:15
+msgid "<b>Network</b>"
+msgstr "<b>Мережа</b>"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:16
+#: src/paperwork/frontend/multiscan/multiscan.glade.h:2
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:34
+msgid "Scan"
+msgstr "Зісканувати"
+
+#: src/paperwork/frontend/settingswindow/settingswindow.glade.h:17
+msgid "<b>Scanner calibration</b>"
+msgstr "<b>Калібрування сканера</b>"
+
+#: src/paperwork/frontend/aboutdialog/aboutdialog.glade.h:1
+msgid "About"
+msgstr "Про програму"
+
+#: src/paperwork/frontend/aboutdialog/aboutdialog.glade.h:2
+msgid "\n"
+msgstr "\n"
+
+#: src/paperwork/frontend/aboutdialog/aboutdialog.glade.h:4
+msgid "Grep for Dead Trees"
+msgstr "Пошук по мертвому дереву"
+
+#: src/paperwork/frontend/multiscan/multiscan.glade.h:1
+msgid "From scanner feeder"
+msgstr "З подачі сканера"
+
+#: src/paperwork/frontend/multiscan/multiscan.glade.h:3
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:33
+msgid "Documents"
+msgstr "Документи"
+
+#: src/paperwork/frontend/multiscan/multiscan.glade.h:4
+msgid "Number of pages"
+msgstr "Кількість сторінок"
+
+#: src/paperwork/frontend/searchdialog/searchdialog.glade.h:1
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:35
+msgid "Search"
+msgstr "Пошук"
+
+#: src/paperwork/frontend/diag/diagdialog.glade.h:1
+msgid "Please wait"
+msgstr "Заждіть"
+
+#: src/paperwork/frontend/labeleditor/labeleditor.glade.h:1
+msgid "Label editor"
+msgstr "Редактор міток"
+
+#: src/paperwork/frontend/labeleditor/labeleditor.glade.h:3
+msgid "Color"
+msgstr "Колір"
+
+#: src/paperwork/frontend/labeleditor/labeleditor.glade.h:4
+msgid "Pick"
+msgstr "Вибрати"
+
+#: src/paperwork/frontend/import/importfileselector.glade.h:1
+msgid "Select a file or a directory to import"
+msgstr "Виберіть файл або каталог для імпортування"
+
+#: src/paperwork/frontend/import/importaction.glade.h:1
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:2
+msgid "Import file(s)"
+msgstr "Імпортувати файли"
+
+#: src/paperwork/frontend/import/importaction.glade.h:2
+msgid "<b>Please select an action</b>"
+msgstr "<b>Виберіть дію</b>"
+
+#: src/paperwork/frontend/mainwindow/export.glade.h:2
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:5
+msgid "Export"
+msgstr "Експортувати"
+
+#: src/paperwork/frontend/mainwindow/export.glade.h:3
+msgid "File format"
+msgstr "Формат файла"
+
+#: src/paperwork/frontend/mainwindow/export.glade.h:4
+msgid "Page format"
+msgstr "Формат сторінки"
+
+#: src/paperwork/frontend/mainwindow/export.glade.h:5
+msgid "Simplification"
+msgstr "Спрощення"
+
+#: src/paperwork/frontend/mainwindow/export.glade.h:6
+msgid "Quality"
+msgstr "Якість"
+
+#: src/paperwork/frontend/mainwindow/export.glade.h:7
+msgid "Estimated Size"
+msgstr "Приблизний розмір"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:1
+msgid "Scan from feeder"
+msgstr "Зісканувати з подачі"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:3
+msgid "Open directory"
+msgstr "Відкрити каталог"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:4
+msgid "Print"
+msgstr "Надрукувати"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:6
+msgid "Page"
+msgstr "Сторінка"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:8
+msgid "Redo OCR"
+msgstr "Скасувати отекстування"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:9
+msgid "Fit full page"
+msgstr "За всією сторінкою"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:10
+msgid "Fit page width"
+msgstr "За шириною сторінки"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:12
+#, no-c-format
+msgid "10%"
+msgstr "10%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:14
+#, no-c-format
+msgid "15%"
+msgstr "15%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:16
+#, no-c-format
+msgid "25%"
+msgstr "25%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:18
+#, no-c-format
+msgid "50%"
+msgstr "50%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:20
+#, no-c-format
+msgid "70%"
+msgstr "70%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:22
+#, no-c-format
+msgid "85%"
+msgstr "85%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:24
+#, no-c-format
+msgid "100%"
+msgstr "100%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:26
+#, no-c-format
+msgid "125%"
+msgstr "125%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:28
+#, no-c-format
+msgid "150%"
+msgstr "150%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:30
+#, no-c-format
+msgid "175%"
+msgstr "175%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:32
+#, no-c-format
+msgid "200%"
+msgstr "200%"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:36
+msgid "Advanced search"
+msgstr "Розширений пошук"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:37
+msgid "Additional keywords"
+msgstr "Додаткові ключові слова"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:38
+msgid "Highlight words"
+msgstr "Підкреслювати слова"
+
+#: src/paperwork/frontend/mainwindow/mainwindow.glade.h:39
+msgid ""
+"If by any chance character recognition doesn't work, type in a few keywords "
+"so you'll be able to search for them."
+msgstr ""
+"Якщо раптом розпізнавання символів не працює, введіть кілька ключових фраз, "
+"і ви зможете шукати за ними."
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:1
+msgid "_File"
+msgstr "_Файл"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:2
+msgid "_Settings"
+msgstr "_Параметри"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:3
+msgid "_Advanced"
+msgstr "_Додатково"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:4
+msgid "_Diagnostic"
+msgstr "_Діагностика"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:5
+msgid "Optimize index"
+msgstr "Оптимізувати індекс"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:6
+msgid "Reindex all the documents"
+msgstr "Переіндексувати всі документи"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:7
+msgid "Redo OCR on all the documents"
+msgstr "Скасувати отекстування всіх документів"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:8
+msgid "_Help"
+msgstr "_Довідка"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:9
+msgid "_Introduction"
+msgstr "_Вступ"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:10
+msgid "User Manual"
+msgstr "Інструкція користувача"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:11
+msgid "Translator Guide"
+msgstr "Інструкція перекладача"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:12
+msgid "Developer Guide"
+msgstr "Інструкція розробника"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:13
+msgid "_About"
+msgstr "_Про програму"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:14
+msgid "A_ctivate"
+msgstr "_Активувати"
+
+#: src/paperwork/frontend/mainwindow/appmenu.xml.h:15
+msgid "_Quit"
+msgstr "Ви_йти"

--- a/localize.sh
+++ b/localize.sh
@@ -4,7 +4,8 @@
 # For each language, the most common system locale and its short writing
 # must be specified (separated by ':')
 LANGS="fr_FR.UTF-8:fr
-de_DE.UTF-8:de"
+de_DE.UTF-8:de
+uk_UA.UTF-8:uk"
 
 usage()
 {
@@ -23,7 +24,7 @@ usage()
 }
 
 if [ -z "${BACKEND_DIRECTORY}" ] ; then
-	BACKEND_DIRECTORY=$(python3 -c "import paperwork_backend; print(paperwork_backend.__file__)")
+	BACKEND_DIRECTORY=$(python -c "import paperwork_backend; print(paperwork_backend.__file__)")
 	BACKEND_DIRECTORY=$(dirname "${BACKEND_DIRECTORY}")
 fi
 
@@ -52,10 +53,10 @@ then
 		echo "[paperwork-backend] Extraction done."
 	fi
 
-	if [ ! -e "${BACKEND_DIRECTORY}/__init__.py" ] ; then
-		echo "[paperwork-backend] paperwork backend sources not found !"
-		exit 1
-	fi
+	#if [ ! -e "${BACKEND_DIRECTORY}/__init__.py" ] ; then
+	#	echo "[paperwork-backend] paperwork backend sources not found !"
+	#	exit 1
+	#fi
 
 	mkdir -p locale
 


### PR DESCRIPTION
Couldn't find https://github.com/openpaperwork/paperwork-backend/blob/unstable/__init__.py
Probably it's not the best practise to manage translations of both backend and frontend within one repository. You have to consider merging the code into one repository or splitting the translations.

So, I've edited localize.sh in order to make it work on my machine. I don't mind if you push only uk.po.

