### PR TITLE
Enforce version for gi loading

### DIFF
--- a/src/paperwork/frontend/mainwindow/__init__.py
+++ b/src/paperwork/frontend/mainwindow/__init__.py
@@ -22,6 +22,10 @@ import sys
 import threading
 
 import gettext
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Notify', '0.7')
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import GLib


### PR DESCRIPTION
when running
$ paperwork-shell install
I had this kind of warnings & errors in develop mode. This fixes the
initial warnings.

/home/teto/paperwork/src/paperwork/frontend/mainwindow/__init__.py:30: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
/home/teto/paperwork/src/paperwork/frontend/mainwindow/__init__.py:31: PyGIWarning: Notify was imported without specifying a version first. Use gi.require_version('Notify', '0.7') before import to ensure that the right version gets loaded.
  from gi.repository import Notify
Installing /home/teto/.local/share/icons/hicolor/16/apps/paperwork.png ...
{
    "args": "(2, 'Aucun fichier ou dossier de ce type')",
    "exception": "<class 'FileNotFoundError'>",
    "reason": "[Errno 2] Aucun fichier ou dossier de ce type: '/home/teto/paperwork/src/paperwork/frontend/share/icons/hicolor/16/apps/paperwork.png'",
    "status": "error"
}
Traceback (most recent call last):
  File "/home/teto/.local/bin/paperwork-shell", line 11, in <module>
    load_entry_point('paperwork-backend', 'console_scripts', 'paperwork-shell')()
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 204, in main
    sys.exit(COMMANDS[args.cmd](*args.cmd_args))
  File "/home/teto/paperwork/src/paperwork/frontend/shell.py", line 89, in install
    shutil.copyfile(src, dst)
  File "/usr/lib/python3.5/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] Aucun fichier ou dossier de ce type: '/home/teto/paperwork/src/paperwork/frontend/share/icons/hicolor/16/apps/paperwork.png'