### PR TITLE
Fix AttributeError exception thrown when importing file from the shell

### DIFF
--- a/paperwork-backend/paperwork_backend/shell.py
+++ b/paperwork-backend/paperwork_backend/shell.py
@@ -483,10 +483,10 @@ def _do_import(filepaths, dsearch, doc, ocr=None, ocr_lang=None,
             r['guessed_labels'].append(
                 {
                     "docid": doc.docid,
-                    "labels": [label.name for label in labels],
+                    "labels": [label.name for (label, scores) in labels],
                 }
             )
-            for label in labels:
+            for (label, scores) in labels:
                 dsearch.add_label(doc, label, update_index=False)
         verbose("Document {} (labels: {})".format(
             doc.docid,


### PR DESCRIPTION
When running paperwork-shell -b import blah.pdf I get the following error output:

Running OCR on page 20180316_0656_20|0
{
    "args": "(\"'tuple' object has no attribute 'name'\",)",
    "exception": "<class 'AttributeError'>",
    "reason": "'tuple' object has no attribute 'name'",
    "status": "error"
}
Traceback (most recent call last):
  File "/usr/bin/paperwork-shell", line 11, in <module>
    load_entry_point('paperwork-backend==1.2.4', 'console_scripts', 'paperwork-shell')()
  File "/usr/lib/python3.6/site-packages/paperwork_backend/shell_cmd.py", line 214, in main
    sys.exit(COMMANDS[args.cmd](*args.cmd_args))
  File "/usr/lib/python3.6/site-packages/paperwork_backend/shell.py", line 612, in cmd_import
    return _do_import(args, dsearch, doc, ocr, ocr_lang, guess_labels)
  File "/usr/lib/python3.6/site-packages/paperwork_backend/shell.py", line 486, in _do_import
    "labels": [label.name for label in labels],
  File "/usr/lib/python3.6/site-packages/paperwork_backend/shell.py", line 486, in <listcomp>
    "labels": [label.name for label in labels],
AttributeError: 'tuple' object has no attribute 'name'

This pull request fixes the issue for me.