### PR TITLE
Use the real new document id

### DIFF
--- a/paperwork-backend/paperwork_backend/shell.py
+++ b/paperwork-backend/paperwork_backend/shell.py
@@ -835,7 +835,7 @@ def cmd_rename(old_docid, new_docid):
     verbose("Document {} renamed into {}".format(old_docid, new_docid))
     reply({
         "old_docid": old_docid,
-        "new_docid": new_docid
+        "new_docid": doc.docid
     })
 
 


### PR DESCRIPTION
When I rename tow document with the same name, the second document name will be postfixed, and this postfix should be returned.